### PR TITLE
chore: update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: "docs"
 repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.6
+  rev: v0.15.22
   hooks:
     - id: ruff-check
       args: [ --fix ]
@@ -19,9 +19,9 @@ repos:
   rev: v3.21.2
   hooks:
   - id: pyupgrade
-    args: [--py38-plus]
+    args: [--py311-plus]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.18.2
+  rev: v2.3.0
   hooks:
     - id: mypy
       language_version: python3


### PR DESCRIPTION
## Summary by Sourcery

Update pre-commit tooling to newer versions and align Python target version for code quality checks.

Build:
- Bump ruff-pre-commit hook version to v0.15.22 in pre-commit configuration.
- Update pyupgrade configuration to target Python 3.11+ in pre-commit hooks.
- Upgrade mypy mirror hook to v2.3.0 in pre-commit configuration.